### PR TITLE
aggiornata la modalità di formattazione dei Paragraph

### DIFF
--- a/code/Paragraph.py
+++ b/code/Paragraph.py
@@ -32,22 +32,30 @@ class Paragraph:
         while prfxLen <= self.__localSentences.__len__():
             subParagraph = Paragraph(self.__globalSentence, self.__trcClass)
             for i in range(prfxLen):
-                subParagraph.addLocalSentence(self.__localSentences[i])
+                subParagraph.addLocalSentence(self.getLocalSentence(i))
             self.__prefixSet.append(subParagraph)
             prfxLen += 1
         return self.__prefixSet
 
-    def __str__(self):
+    def formatParagraph(self):
         paragraphstr = ''
         for i in self.__prefixSet:
             prefixstr = ''
             for localSentence in i.__localSentences:
-                prefixstr += f'{localSentence};\n'
+                prefixstr += f'{localSentence}\n'
             prefixstr += f'{i.getGlobalSentence()}\n'
-            paragraphstr += f'{prefixstr}'
+            paragraphstr += f'{prefixstr}\n'
         return paragraphstr
 
-    def __len__(self, metric: str = 'characters'):
+
+    def __str__(self):
+            prefixstr=''
+            for localSentence in self.__localSentences:
+                prefixstr += f'{localSentence}; '
+            prefixstr += f'{self.getGlobalSentence()}   '
+            return prefixstr
+
+    def Paragraphlen(self, metric: str = 'characters'):
         paragraph_length = 0
         for prfx in self.__prefixSet:
             prefix_length = prfx.__globalSentence.__len__(metric)


### PR DESCRIPTION

il metodo __str__() ora converte in stringa solo i prefix, ho fatto questa scelta per questione di comodità perché nella fase di train e test verranno usate liste di prefix, se avessi imputato la loro rappresentazione in forma di stringa ad un metodo apposito sarebbe stato richiesto di andare a manipolare le classi dedite alla trasformazione in textDataset. ho preferito quindi usare questa soluzione per il Paragraph, tramite il metodo formatParagraph() questo sarà formattato in maniera leggibile, trova un uso nel caso si voglia visualizzare il text.